### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe jQuery plugin

### DIFF
--- a/TestAppAlex/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/TestAppAlex/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -1083,7 +1083,7 @@ $.extend( $.validator, {
 			}
 
 			// Always apply ignore filter
-			return $( element ).not( this.settings.ignore )[ 0 ];
+			return $.find( element ).not( this.settings.ignore )[ 0 ];
 		},
 
 		checkable: function( element ) {


### PR DESCRIPTION
Potential fix for [https://github.com/GaLeX13/SE-CloudSync/security/code-scanning/5](https://github.com/GaLeX13/SE-CloudSync/security/code-scanning/5)

To fix the problem, we need to ensure that any user-controlled input is properly sanitized before being used in jQuery selectors. Specifically, we should use methods that treat the input strictly as a CSS selector rather than potentially interpreting it as HTML.

- Replace the use of `$(element)` with `$.find(element)` to ensure the input is always treated as a CSS selector.
- Update the `validationTargetFor` function to use this safer method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
