### PR TITLE
Potential fix for code scanning alert no. 4: Unsafe jQuery plugin

### DIFF
--- a/TestAppAlex/wwwroot/lib/jquery-validation/dist/jquery.validate.js
+++ b/TestAppAlex/wwwroot/lib/jquery-validation/dist/jquery.validate.js
@@ -686,7 +686,7 @@ $.extend( $.validator, {
 		},
 
 		clean: function( selector ) {
-			return $( selector )[ 0 ];
+			return $.find(selector)[ 0 ];
 		},
 
 		errors: function() {


### PR DESCRIPTION
Potential fix for [https://github.com/GaLeX13/SE-CloudSync/security/code-scanning/4](https://github.com/GaLeX13/SE-CloudSync/security/code-scanning/4)

To fix the problem, we need to ensure that the `selector` parameter is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method instead of the `jQuery` method, which ensures that the input is interpreted as a CSS selector.

- Modify the `clean` function to use `jQuery.find` instead of `jQuery`.
- Ensure that the `selector` parameter is properly sanitized and validated before being used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
